### PR TITLE
MOD style to context for Typst v0.12

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -53,7 +53,7 @@
     "\n"
   )
 
-  show raw.where(block: true): it => style(styles => {
+  show raw.where(block: true): it => context {
     let lines = lines
 
     if lines == auto {
@@ -70,7 +70,7 @@
 
     lines = (lines.at(0) - 1, lines.at(1))
 
-    let maximum-number-length = measure(number-style(lines.at(1)), styles).width
+    let maximum-number-length = measure(number-style(lines.at(1))).width
 
     block(
       inset: inset,
@@ -128,7 +128,7 @@
         )
       }
     )
-  })
+  }
 
   raw(block: true, lang: source.lang, unlabelled-source)
 }


### PR DESCRIPTION
Thanks for the great package. We love to use it.

I started using Typst v0.12.0 and now I get a warning.

Apparently, `style` is to be deprecate and `context` is to be used instead.
https://typst.app/docs/reference/foundations/style/

I kindly ask for your confirmation on the suggestion.